### PR TITLE
Add CTE-440 support

### DIFF
--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -533,3 +533,19 @@ MaxPressure 2047
 Width 101.6
 Height 56.6
 
+
+#
+# Wacom CTE-440 (Graphite4 4x5)
+#
+Tablet 0x056A 0x0015 0xFF0D 0x0001
+Tablet 0x056A 0x0015 0x000D 0x0001
+Name "Wacom CTE-440"
+ReportLength 9
+DetectMask 0x00
+MaxX 10208
+MaxY 7424
+MaxPressure 511
+Width 102.08
+Height 74.24
+InitFeature 0x02 0x02
+


### PR DESCRIPTION
Copied from the CTE-450 config with a few adjustments from the following pages:

https://github.com/linuxwacom/input-wacom/wiki/Device-IDs

https://github.com/linuxwacom/input-wacom/blob/master/4.5/wacom_wac.c#L4077

Works normally as far as I can tell