### PR TITLE
Add PTH-660 config.

### DIFF
--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -379,6 +379,52 @@ InitFeature 0x02 0x02
 Type WacomIntuos
 
 
+#
+# Wacom PTH-660 (USB)
+#
+Tablet 0x056A 0x0357 0xFF0D 0x0001
+Name "Wacom PTH-660"
+ReportId 0x10
+ReportLength 192
+DetectMask 0x40
+MaxX 44800
+MaxY 29600
+MaxPressure 8191
+Width 226.0
+Height 150.0
+Type Wacom4100
+
+
+#
+# Wacom PTH-660 (USB) (Wacom drivers installed)
+#
+Tablet 0x056A 0x0357 0xFF00 0x000A
+Name "Wacom PTH-660 (Wacom drivers installed)"
+ReportId 0x10
+ReportLength 193
+DetectMask 0x40
+MaxX 44800
+MaxY 29600
+MaxPressure 8191
+Width 226.0
+Height 150.0
+Type Wacom4100
+
+
+#
+# Wacom PTH-660 (Bluetooth)
+#
+Tablet 0x056a 0x0360 0xFF0D 0x0001
+Name "Wacom PTH-660 Bluetooth (Experimental)"
+ReportId100 Bluetooth
+ReportLength 361
+DetectMask 0xE0
+MaxX 44800
+MaxY 29600
+MaxPressure 8191
+Width 226.0
+Height 150.0
+
 
 #
 # XP-Pen G430


### PR DESCRIPTION
This adds support for the Intuos Pro M (2017) over USB, USB with the official drivers installed, and Bluetooth. This commit is using the CTL-4100's codepath for packet handling.

Note that https://github.com/linuxwacom/input-wacom/wiki/Device-IDs lists the PTH-660 as using a 2nd-generation Wacom USB interface, while it lists the CTL-4100 as using 3rd-generation. It's possible some incompatibility may crop up here from treating this internally as a CTL-4100. I have tested this config with a PTH-660 on all 3 included interfaces, and it seems to handle pen position and button clicks properly.