### PR TITLE
Add support for UC-Logic M508 tablet

### DIFF
--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -994,6 +994,21 @@ Width 160.0
 Height 120.0
 InitStrings 100 200
 
+#
+# Huion M508 (Used in M580 and K58, presumably more)
+#
+USBTablet "{62F12D4C-3431-4EFD-8DD7-8E9AAB18D30C}"
+CheckString 121 "M508"
+Name "Huion M508 (Internal)"
+ReportId 0x07
+ReportLength 8
+DetectMask 0x80
+MaxX 32000
+MaxY 20000
+MaxPressure 2047
+Width 203.2
+Height 127
+InitStrings 100 200
 
 #
 # Huion osu!tablet


### PR DESCRIPTION
This tablet is used in the Huion K58 and the Huion 580

There dont seem to be any issues with the driver - my K58 works fine.

Closes #255 and #361 