### PR TITLE
Add Gaomon S620 Support

### DIFF
--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -996,6 +996,32 @@ InitStrings 100 200
 
 
 #
+# Gaomon S620
+#
+USBTablet "{62F12D4C-3431-4EFD-8DD7-8E9AAB18D30C}"
+CheckString 201 "OEM02_T18e_190329"
+Name "Gaomon S620"
+ReportId 0x00
+ReportLength 16
+DetectMask 0x80
+MaxX 33020
+MaxY 20320
+MaxPressure 8191
+Width 165.1
+Height 101.6
+InitStrings 100 200
+InitStrings 100 200
+AuxReportId 0x08
+AuxReportLength 12
+AuxDetectMask 0xE0
+AuxgnoreMask 0x80
+AuxCustomData ReportId Source=0
+AuxCustomData ButtonsLow Source=4 SourceMask=0x3F
+AuxCustomData Detect Source=1
+AuxButtonCount 4
+
+
+#
 # Huion osu!tablet
 #
 USBTablet "{62F12D4C-3431-4EFD-8DD7-8E9AAB18D30C}"


### PR DESCRIPTION
Added S620 support with Huion drivers and button compatibility.

Edit: Requires the Huion drivers Hawku provides just like other Huion/Gaomon tablets.